### PR TITLE
Add Rector for PHP 8 with PR testing

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BRANCH_NAME: 0.1.x
+  TARGET_PHP_CONSTRAINT: ^8.0
 
 concurrency:
   group: phar-${{ github.ref }} # will be canceled on subsequent pushes in both branches and pull requests
@@ -39,6 +40,12 @@ jobs:
           extensions: mbstring, intl
 
       - name: "Install dependencies"
+        run: "composer install --no-interaction --no-progress"
+
+      - name: "Downgrade for PHP compatibility"
+        run: "vendor/bin/rector -c build/rector-downgrade.php process"
+
+      - name: "Remove dev dependencies"
         run: "composer install --no-dev --no-interaction --no-progress"
 
       - name: "Compile PHAR"
@@ -90,6 +97,58 @@ jobs:
 
       - name: "Delete checksum PHAR"
         run: "rm tmp/cucumber-linter.phar"
+
+  phpstan-lint:
+    name: PHPStan
+    runs-on: "ubuntu-latest"
+
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: 8.2
+          tools: cs2pr
+
+      - name: "Install dependencies"
+        run: "composer install --no-interaction --no-progress"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpstan --error-format=checkstyle | cs2pr"
+
+  phpunit-test:
+    name: PHPUnit Testing
+    runs-on: "ubuntu-latest"
+
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Install PHP for set-up"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: 8.2
+
+      - name: "Install dependencies"
+        run: "composer install --no-interaction --no-progress"
+
+      - name: "Downgrade for PHP compatibility"
+        run: "vendor/bin/rector -c build/rector-downgrade.php process"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit --log-junit $GITHUB_WORKSPACE/test-reports/phpunit.xml tests"
 
   commit:
     name: "Commit PHAR"

--- a/build/rector-downgrade.php
+++ b/build/rector-downgrade.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\Semver\VersionParser;
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp81\Rector\FunctionLike\DowngradePureIntersectionTypeRector;
+use Rector\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector;
+use Rector\DowngradePhp82\Rector\Class_\DowngradeReadonlyClassRector;
+
+return static function (RectorConfig $config): void {
+  $parsePhpVersion = static function (string $version, int $defaultPatch = 0): int {
+    $parts = array_map('intval', explode('.', $version));
+
+    return $parts[0] * 10000 + $parts[1] * 100 + ($parts[2] ?? $defaultPatch);
+  };
+
+  $targetPhpConstraint = getenv('TARGET_PHP_CONSTRAINT') ?: throw new \Exception("Must specify TARGET_PHP_CONSTRAINT");
+  $targetPhpVersionId = $parsePhpVersion((new VersionParser())->parseConstraints($targetPhpConstraint)->getLowerBound()->getVersion());
+
+  $config->paths([
+    __DIR__ . '/../src',
+    __DIR__ . '/../tests',
+  ]);
+  $config->phpVersion($targetPhpVersionId);
+  $config->disableParallel();
+
+  if ($targetPhpVersionId < 80200) {
+    $config->rule(DowngradeReadonlyClassRector::class);
+  }
+
+  if ($targetPhpVersionId < 80100) {
+    $config->rule(DowngradeReadonlyPropertyRector::class);
+    $config->rule(DowngradePureIntersectionTypeRector::class);
+  }
+};

--- a/composer.json
+++ b/composer.json
@@ -43,11 +43,13 @@
         "bin/cucumber-linter"
     ],
     "require-dev": {
+        "composer/semver": "^3.4",
         "phpstan/extension-installer": "*",
         "phpstan/phpstan": "*",
         "phpstan/phpstan-deprecation-rules": "*",
         "phpstan/phpstan-phpunit": "*",
         "phpstan/phpstan-strict-rules": "*",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+        "rector/rector": "^0.18.10"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "295c1e7019e412ad2b81bbd3dcab67b0",
+    "content-hash": "f4de25b600f17735d09de4f3b6623065",
     "packages": [
         {
             "name": "cucumber/gherkin",
@@ -1313,6 +1313,87 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/semver",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-31T09:50:34+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.11.1",
             "source": {
@@ -2214,6 +2295,62 @@
                 }
             ],
             "time": "2023-10-26T07:21:45+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.18.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "f36bc0a707fd8af301df5108740ce41f9db8eded"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/f36bc0a707fd8af301df5108740ce41f9db8eded",
+                "reference": "f36bc0a707fd8af301df5108740ce41f9db8eded",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.35"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.18.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-16T19:42:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This adds a Rector script to downgrade Cucumber Linter to PHP 8 which allows us to develop with the newest PHP features on PHP 8.2 or 8.3 while installing can happen on PHP 8.

To ensure this works we add testing for pull requests on the different PHP versions that tests the downgraded PHP versions.

We can still improve here and use a class loader in a similar manner as PHPStan does to load classes from within the compiled PHAR so that we know we're actually testing the downgraded and packaged version rather than only the downgraded code.